### PR TITLE
Added condition when assetName does not exist

### DIFF
--- a/RiskAccept/AcceptRiskRules.py
+++ b/RiskAccept/AcceptRiskRules.py
@@ -315,6 +315,9 @@ def parserules(sc, rules):
         elif rule['hostType'] == 'asset':
             assetID = rule['hostValue']['id']
             assetName = rule['hostValue']['name']
+            if assetID == "-1":
+                logger.warning("Asset named: {} does not exist. Line has been skipped.".format(assetName))
+                continue
             getassets = sc.analysis(
                 ('assetID', '=', assetID), ('repositoryIDs', '=', rule['repository']['id']), tool='sumip')
 


### PR DESCRIPTION
When an asset does not exist, assetID returned is "-1", which provoke an error on pysecuritycenter as below:
> python.exe .\RiskAccept\AcceptRiskRules.py
2018-11-06 13:35:06,255 - pyLogging - INFO - Running on Python version 3.7.0 (v3.7.0:1bf9cc5093, Jun 27 2018, 04:59:51) [MSC v.1914 64 bit (AMD64)]
2018-11-06 13:35:06,889 - pyLogging - INFO - Getting Accept Risk Rules from SecurityCenter
2018-11-06 13:36:21,987 - pyLogging - ERROR - Error parsing Accept Risk Rules in getRuleData function
2018-11-06 13:36:21,987 - pyLogging - ERROR - Data string follows
2018-11-06 13:36:21,990 - pyLogging - ERROR - '[143]: Filter "assetID" must be an integer.\n'
Traceback (most recent call last):
  File ".\RiskAccept\AcceptRiskRules.py", line 209, in getRuleData
    return parserules(sc, rules)
  File ".\RiskAccept\AcceptRiskRules.py", line 319, in parserules
    ('assetID', '=', assetID), ('repositoryIDs', '=', rule['repository']['id']), tool='sumip')
  File "C:\Program Files\python37\lib\site-packages\securitycenter\sc5.py", line 136, in analysis
    resp = self.post('analysis', json=kwargs)
  File "C:\Program Files\python37\lib\site-packages\securitycenter\base.py", line 96, in post
    return self._resp_error_check(resp)
  File "C:\Program Files\python37\lib\site-packages\securitycenter\sc5.py", line 31, in _resp_error_check
    raise APIError(d['error_code'], d['error_msg'])
securitycenter.base.APIError: '[143]: Filter "assetID" must be an integer.\n'
2018-11-06 13:36:21,995 - pyLogging - INFO - Exiting script due to an error